### PR TITLE
Portability 0.2.0

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -13,6 +13,11 @@ Files: bal.code-workspace
 Copyright: 2004-current Ryan M. Lederman <lederman@gmail.com>
 License: MIT
 
+# CMake files
+Files: CMakePresets.json
+Copyright: 2004-current Ryan M. Lederman <lederman@gmail.com>
+License: MIT
+
 # C++ sample applications
 Files: sample/*.cc sample/*.hh
 Copyright: 2004-current Ryan M. Lederman <lederman@gmail.com>

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,6 +1,49 @@
 {
     "configurations": [
         {
+            "name": "gdb: Launch (server)",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/balserver",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "Set Disassembly Flavor to Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ]
+        },
+        {
+            "name": "gdb: Attach (server)",
+            "type": "cppdbg",
+            "request": "attach",
+            "program": "${workspaceFolder}/build/balserver",
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "Set Disassembly Flavor to Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ]
+        },
+        {
             "name": "lldb: Attach (client)",
             "type": "cppdbg",
             "request": "attach",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,21 @@
 {
     "configurations": [
         {
-            "name": "(lldb) Launch balserver",
+            "name": "lldb: Attach (client)",
+            "type": "cppdbg",
+            "request": "attach",
+            "program": "${workspaceFolder}/build/balclient",
+            "MIMode": "lldb"
+        },
+        {
+            "name": "lldb: Attach (server)",
+            "type": "cppdbg",
+            "request": "attach",
+            "program": "${workspaceFolder}/build/balserver",
+            "MIMode": "lldb"
+        },
+        {
+            "name": "lldb: Launch (server)",
             "type": "cppdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/balserver",
@@ -13,7 +27,7 @@
             "MIMode": "lldb"
         },
         {
-            "name": "(lldb) Launch balclient",
+            "name": "lldb: Launch (client)",
             "type": "cppdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/balclient",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",
             "environment": [],
-            "externalConsole": false,
+            "externalConsole": true,
             "MIMode": "gdb",
             "setupCommands": [
                 {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,14 +21,39 @@ set(PROJECT_IS_DEV_BUILD true)
 # create compile commands for static analysis
 set(CMAKE_EXPORT_COMPILE_COMMANDS true)
 
+# select the C/C++ standard we can use based on the CMake version
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.21")
+    set(CMAKE_C_STANDARD, 17)
+else()
+    set(CMAKE_C_STANDARD, 11)
+endif()
+
 # policy settings, so CMake doesn't whine.
 cmake_policy(SET CMP0025 NEW) # AppleClang
 cmake_policy(SET CMP0048 NEW) # project VERSION
 cmake_policy(SET CMP0065 NEW) # ENABLE_EXPORTS
-cmake_policy(SET CMP0126 NEW) # cache
 cmake_policy(SET CMP0056 NEW) # CMAKE_EXE_LINKER_FLAGS
 cmake_policy(SET CMP0066 NEW) # CMAKE_<LANG>_FLAGS_<BUILDTYPE>
-cmake_policy(SET CMP0102 NEW) # mark_as_advanced
+
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.13")
+    cmake_policy(SET CMP0077 NEW) # option
+endif()
+
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.17")
+    cmake_policy(SET CMP0102 NEW) # mark_as_advanced
+endif()
+
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.21")
+    cmake_policy(SET CMP0126 NEW) # cache
+endif()
+
+# define the project
+project(
+    ${PROJECT_NAME}
+    VERSION 0.2.0
+    LANGUAGES C CXX
+    DESCRIPTION "Berkeley Abstraction Layer"
+)
 
 # toolchain-related
 if (WIN32)
@@ -47,23 +72,16 @@ else()
     set(CMAKE_CXX_FLAGS_DEBUG "${C_FLAGS_BASE} -g3 -O0 -DDEBUG -DBAL_DBGLOG")
     set(CMAKE_CXX_FLAGS_RELEASE "${C_FLAGS_BASE} -O3 -D_FORTIFY_SOURCE=2 -DNDEBUG")
 
-    set(CMAKE_EXE_LINKER_FLAGS, "${CMAKE_EXE_LINKER_FLAGS} -pthread")
+    set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+    set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+    find_package(Threads REQUIRED)
 endif()
-
-# define the project
-project(
-    ${PROJECT_NAME}
-    VERSION 0.2.0
-    LANGUAGES C CXX
-    DESCRIPTION "Berkeley Abstraction Layer"
-)
 
 execute_process(
     COMMAND git rev-parse --short --verify HEAD
     OUTPUT_VARIABLE GIT_COMMIT_HASH
     OUTPUT_STRIP_TRAILING_WHITESPACE
     ECHO_OUTPUT_VARIABLE
-    COMMAND_ERROR_IS_FATAL ANY
 )
 
 configure_file(
@@ -133,6 +151,16 @@ target_link_libraries(
     ${STATIC_LIBRARY_NAME}
 )
 
+target_link_libraries(
+    ${SERVER_EXECUTABLE_NAME}
+    Threads::Threads
+)
+
+target_link_libraries(
+    ${CLIENT_EXECUTABLE_NAME}
+    Threads::Threads
+)
+
 target_compile_features(
     ${CLIENT_EXECUTABLE_NAME}
     PUBLIC
@@ -148,13 +176,13 @@ target_compile_features(
 target_compile_features(
     ${STATIC_LIBRARY_NAME}
     PUBLIC
-    c_std_17
+    ${CMAKE_C_STANDARD}
 )
 
 target_compile_features(
     ${SHARED_LIBRARY_NAME}
     PUBLIC
-    c_std_17
+    ${CMAKE_C_STANDARD}
 )
 
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,12 +21,21 @@ set(PROJECT_IS_DEV_BUILD true)
 # create compile commands for static analysis
 set(CMAKE_EXPORT_COMPILE_COMMANDS true)
 
-# select the C/C++ standard we can use based on the CMake version
+# select the C/C++ standards we can use based on the CMake version
 if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.21")
-    set(CMAKE_C_STANDARD, 17)
+    set(CMAKE_C_STANDARD 17)
 else()
-    set(CMAKE_C_STANDARD, 11)
+    set(CMAKE_C_STANDARD 11)
 endif()
+
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12")
+    set(CMAKE_CXX_STANDARD 20)
+else()
+    set(CMAKE_CXX_STANDARD 17)
+endif()
+
+set(CMAKE_C_STANDARD_REQUIRED TRUE)
+set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 
 # policy settings, so CMake doesn't whine.
 cmake_policy(SET CMP0025 NEW) # AppleClang
@@ -52,7 +61,7 @@ project(
     ${PROJECT_NAME}
     VERSION 0.2.0
     LANGUAGES C CXX
-    DESCRIPTION "Berkeley Abstraction Layer"
+    DESCRIPTION "Berkeley Abstraction Layer Library"
 )
 
 # toolchain-related
@@ -61,8 +70,9 @@ if (WIN32)
     set(CMAKE_C_FLAGS_DEBUG "${C_FLAGS_BASE} ${CMAKE_C_FLAGS} /MP /W4 /DDEBUG /DBAL_DBGLOG")
     set(CMAKE_C_FLAGS_RELEASE "${C_FLAGS_BASE} ${CMAKE_C_FLAGS} /MP /W4 /DNDEBUG")
 
-    set(CMAKE_CXX_FLAGS_DEBUG "${C_FLAGS_BASE} /DDEBUG /DBAL_DBGLOG")
-    set(CMAKE_CXX_FLAGS_RELEASE "${C_FLAGS_BASE} /DNDEBUG")
+    set(CXX_FLAGS_BASE "")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CXX_FLAGS_BASE} /DDEBUG /DBAL_DBGLOG")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CXX_FLAGS_BASE} /DNDEBUG")
 else()
     set(C_FLAGS_BASE "-Wall -Wextra -Wpedantic -Werror")
     set(CMAKE_C_FLAGS_DEBUG "${C_FLAGS_BASE} -g3 -O0 -DDEBUG -DBAL_DBGLOG")
@@ -151,6 +161,7 @@ target_link_libraries(
     ${STATIC_LIBRARY_NAME}
 )
 
+if(!WIN32)
 target_link_libraries(
     ${SERVER_EXECUTABLE_NAME}
     Threads::Threads
@@ -160,29 +171,30 @@ target_link_libraries(
     ${CLIENT_EXECUTABLE_NAME}
     Threads::Threads
 )
+endif()
 
 target_compile_features(
     ${CLIENT_EXECUTABLE_NAME}
     PUBLIC
-    cxx_std_20
+    ${CXX_STANDARD}
 )
 
 target_compile_features(
     ${SERVER_EXECUTABLE_NAME}
     PUBLIC
-    cxx_std_20
+    ${CXX_STANDARD}
 )
 
 target_compile_features(
     ${STATIC_LIBRARY_NAME}
     PUBLIC
-    ${CMAKE_C_STANDARD}
+    ${C_STANDARD}
 )
 
 target_compile_features(
     ${SHARED_LIBRARY_NAME}
     PUBLIC
-    ${CMAKE_C_STANDARD}
+    ${C_STANDARD}
 )
 
 install(

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -6,8 +6,8 @@
     "version": 6,
     "cmakeMinimumRequired": {
         "major": 3,
-        "minor": 22,
-        "patch": 1
+        "minor": 18,
+        "patch": 4
     },
     "configurePresets": [
         {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,7 +1,3 @@
-/*
-    SPDX-License-Identifier: MIT
-    SPDX-FileCopyrightText: Copyright (c) 2004-current Ryan M. Lederman
-*/
 {
     "version": 6,
     "cmakeMinimumRequired": {

--- a/include/bal.h
+++ b/include/bal.h
@@ -51,7 +51,7 @@ int bal_sock_destroy(bal_socket** s);
 int bal_close(bal_socket** s, bool destroy);
 int bal_shutdown(bal_socket* s, int how);
 
-int bal_connect(const bal_socket* s, const char* host, const char* port);
+int bal_connect(bal_socket* s, const char* host, const char* port);
 int bal_connectaddrlist(bal_socket* s, bal_addrlist* al);
 
 int bal_send(const bal_socket* s, const void* data, bal_iolen len, int flags);

--- a/include/bal/helpers.h
+++ b/include/bal/helpers.h
@@ -58,12 +58,12 @@ void __bal_safefree(void** pp)
 # define bal_isbitset(bitmask, bit) (((bitmask) & (bit)) == (bit))
 
 # define bal_setbitshigh(pbitmask, bits) \
-    if ((pbitmask)) { \
+    if (NULL != (pbitmask)) { \
         (*(pbitmask)) |= (bits); \
     }
 
 # define bal_setbitslow(pbitmask, bits) \
-    if ((pbitmask)) { \
+    if (NULL != (pbitmask)) { \
         (*(pbitmask)) &= ~(bits); \
     }
 

--- a/include/bal/helpers.h
+++ b/include/bal/helpers.h
@@ -29,6 +29,7 @@
 # include "types.h"
 # include "errors.h"
 
+/** Sets the specified pointer-to-pointer's value to NULL after free(). */
 static inline
 void __bal_safefree(void** pp)
 {
@@ -38,48 +39,71 @@ void __bal_safefree(void** pp)
     }
 }
 
+/** Coalesces types into void** for use by __bal_safefree. */
 # define _bal_safefree(pp) __bal_safefree((void**)(pp))
 
+/** Whether the specified pointeris non-null. Sets last error to EINVAL if not. */
 # define _bal_validptr(p) \
     (NULL != (p) ? true : _bal_handleerr(EINVAL))
 
+/** Whether the specified pointer-to-pointer is non-null. Sets last error to
+ * EINVAL if not. */
 # define _bal_validptrptr(pp) \
     (NULL != (pp) ? true : _bal_handleerr(EINVAL))
 
+/** Whether the specified pointer to string is non-null, and contains a non-zero
+ * value at index 0. Sets last error to EINVAL if not. */
 # define _bal_validstr(str) \
     ((NULL != (str) && '\0' != *(str)) ? true : _bal_handleerr(EINVAL))
 
+/** Whether the specified socket is non-null, and has a valid descriptor
+ * value. Sets last error to EINVAL if not. */
 # define _bal_validsock(s) \
     ((NULL != (s) && BAL_BADSOCKET != (s)->sd) ? true : _bal_handleerr(EINVAL))
 
+/** Whether or not the specified length is > 0. Sets last error to EINVAL if not. */
 # define _bal_validlen(len) \
     ((len) > 0 ? true : _bal_handleerr(EINVAL))
 
+/** Whether or not a particular bit or set of bits are set in a bitmask. */
 # define bal_isbitset(bitmask, bit) (((bitmask) & (bit)) == (bit))
 
+/** Sets the specified bits to one in the target bitmask. */
 # define bal_setbitshigh(pbitmask, bits) \
     if (NULL != (pbitmask)) { \
         (*(pbitmask)) |= (bits); \
     }
 
+/** Sets the specified bits to zero in the target bitmask. */
 # define bal_setbitslow(pbitmask, bits) \
     if (NULL != (pbitmask)) { \
         (*(pbitmask)) &= ~(bits); \
     }
 
+/** Returns the size of a sockaddr (IPv4/IPv6). */
 # define _BAL_SASIZE(sa) \
     ((PF_INET6 == ((struct sockaddr* )&(sa))->sa_family) \
         ? sizeof(struct sockaddr_in6) : sizeof(struct sockaddr_in))
 
+/** Returns the number of entries in an array. */
 # define _bal_countof(arr) (sizeof((arr)) / sizeof((arr)[0]))
 
+/** Allows a parameter to be unreferenced without compiler warnings. */
 # define BAL_UNUSED(var) (void)(var)
 
+/** Used with getnameinfo: do not perform DNS queries. */
+# define _BAL_NI_NODNS (NI_NUMERICHOST | NI_NUMERICSERV)
+
+/** Used with getnameinfo: perform DNS queries. */
+# define _BAL_NI_DNS   (NI_NAMEREQD | NI_NUMERICSERV)
+
+/** Locks the specified mutex, asserts that it was locked and enters an if-block. */
 # define _BAL_ENTER_MUTEX(m, name) \
     bool name##_locked = _bal_mutex_lock(m); \
     BAL_ASSERT(name##_locked); \
     if (name##_locked) {
 
+/** Unlocks a mutex, asserts that it was unlocked and ends an if-block. */
 # define _BAL_LEAVE_MUTEX(m, name) \
     bool name##_unlocked = _bal_mutex_unlock(m); \
     BAL_ASSERT_UNUSED(name##_unlocked, name##_unlocked); \

--- a/include/bal/internal.h
+++ b/include/bal/internal.h
@@ -53,7 +53,7 @@ int _bal_getnameinfo(int f, const bal_sockaddr* in, char* host, char* port);
 
 bool _bal_ispendingconn(bal_socket* s);
 
-uint32_t _bal_pollflags_tomask(short flags);
+uint32_t _bal_pollflags_toevents(short flags);
 short _bal_mask_topollflags(uint32_t mask);
 
 bal_threadret _bal_eventthread(void* ctx);

--- a/include/bal/internal.h
+++ b/include/bal/internal.h
@@ -52,6 +52,7 @@ int _bal_getaddrinfo(int flags, int addr_fam, int type, const char* host,
 int _bal_getnameinfo(int f, const bal_sockaddr* in, char* host, char* port);
 
 bool _bal_ispendingconn(bal_socket* s);
+bool _bal_isclosedconn(bal_socket* s);
 
 uint32_t _bal_pollflags_toevents(short flags);
 short _bal_mask_topollflags(uint32_t mask);

--- a/include/bal/internal.h
+++ b/include/bal/internal.h
@@ -42,8 +42,8 @@ bool _bal_cleanup(void);
 
 int _bal_asyncpoll(bal_socket* s, bal_async_cb proc, uint32_t mask);
 
-bool _bal_initasyncpoll(void);
-bool _bal_cleanupasyncpoll(void);
+bool _bal_init_asyncpoll(void);
+bool _bal_cleanup_asyncpoll(void);
 
 int _bal_sock_destroy(bal_socket** s);
 
@@ -51,15 +51,15 @@ int _bal_getaddrinfo(int flags, int addr_fam, int type, const char* host,
     const char* port, struct addrinfo** res);
 int _bal_getnameinfo(int f, const bal_sockaddr* in, char* host, char* port);
 
-bool _bal_ispendingconn(const bal_socket* s);
-bool _bal_isclosedconn(const bal_socket* s);
+bool _bal_is_pending_conn(const bal_socket* s);
+bool _bal_is_closed_conn(const bal_socket* s);
 
-uint32_t _bal_pollflags_toevents(short flags);
-short _bal_mask_topollflags(uint32_t mask);
+uint32_t _bal_pollflags_to_events(short flags);
+short _bal_mask_to_pollflags(uint32_t mask);
 
 bal_threadret _bal_eventthread(void* ctx);
 
-void _bal_dispatchevents(bal_descriptor sd, bal_socket* s, uint32_t events);
+void _bal_dispatch_events(bal_descriptor sd, bal_socket* s, uint32_t events);
 
 /** Creates a new list. */
 bool _bal_list_create(bal_list** lst);
@@ -125,9 +125,14 @@ bool _bal_get_boolean(const bool* boolean);
 void _bal_set_boolean(bool* boolean, bool value);
 # endif
 
+/** Runs the specified function exactly once. */
 bool _bal_once(bal_once* once, bal_once_fn func);
 
+/** Converts an addrinfo linked-list into a bal_addrlist. */
 int _bal_aitoal(struct addrinfo* ai, bal_addrlist* out);
+
+/** Uses the best-avaiable string copying routine. */
+void _bal_strcpy(char* dest, size_t destsz, const char* src, size_t srcsz);
 
 /** Prints a bal_socket to stdout. */
 void _bal_socket_print(const bal_socket* s);
@@ -138,13 +143,12 @@ pid_t _bal_gettid(void);
 # endif
 
 # if defined(__WIN__)
+/** Initializes static data at initialization time. */
 BOOL CALLBACK _bal_static_once_init_func(PINIT_ONCE ponce, PVOID param, PVOID* ctx);
 # else
+/** Initializes static data at initialization time. */
 void _bal_static_once_init_func(void);
 # endif
-
-# define _BAL_NI_NODNS (NI_NUMERICHOST | NI_NUMERICSERV)
-# define _BAL_NI_DNS   (NI_NAMEREQD | NI_NUMERICSERV)
 
 # if defined(__cplusplus)
 }

--- a/include/bal/internal.h
+++ b/include/bal/internal.h
@@ -51,8 +51,8 @@ int _bal_getaddrinfo(int flags, int addr_fam, int type, const char* host,
     const char* port, struct addrinfo** res);
 int _bal_getnameinfo(int f, const bal_sockaddr* in, char* host, char* port);
 
-bool _bal_ispendingconn(bal_socket* s);
-bool _bal_isclosedconn(bal_socket* s);
+bool _bal_ispendingconn(const bal_socket* s);
+bool _bal_isclosedconn(const bal_socket* s);
 
 uint32_t _bal_pollflags_toevents(short flags);
 short _bal_mask_topollflags(uint32_t mask);

--- a/include/bal/platform.h
+++ b/include/bal/platform.h
@@ -35,31 +35,46 @@
 #  elif defined(__linux__)
 #   undef _GNU_SOURCE
 #   define _GNU_SOURCE
-#  elif defined (__FreeBSD__) || defined (__OpenBSD__) || defined (__NetBSD__) || \
-        defined (__DragonFly__)
+#  elif defined(__OpenBSD__)
 #   define __BSD__
-#   undef _BSD_SOURCE
+#   define __FreeBSD_PTHREAD_NP_11_3__
+#  elif defined(__NetBSD__)
+#   define __BSD__
+#   if !defined(_NETBSD_SOURCE)
+#    define _NETBSD_SOURCE 1
+#   endif
+#   define USE_PTHREAD_GETNAME_NP
+#  elif defined (__FreeBSD__) || defined (__DragonFly__)
+#   define __BSD__
 #   define _BSD_SOURCE
+#   if !defined(_DEFAULT_SOURCE)
+#    define _DEFAULT_SOURCE
+#   endif
+#   include <sys/param.h>
+#   if __FreeBSD_version >= 1202500
+#    define __FreeBSD_PTHREAD_NP_12_2__
+#   elif __FreeBSD_version >= 1103500
+#    define __FreeBSD_PTHREAD_NP_11_3__
+#   elif __DragonFly_version >= 400907
+#    define __DragonFly_getthreadid__
+#   endif
+#   if defined(__DragonFly__)
+#    define USE_PTHREAD_GETNAME_NP
+#   endif
 #   define __HAVE_LIBC_STRLCPY__
-#  endif
-#  if !defined(_POSIX_C_SOURCE)
-#   define _POSIX_C_SOURCE 200809L
-#  endif
-#  if !defined(_DEFAULT_SOURCE)
-#   define _DEFAULT_SOURCE
-#  endif
-#  if !defined(_XOPEN_SOURCE)
-#   define _XOPEN_SOURCE 700
+#  else
+#   if !defined(_POSIX_C_SOURCE)
+#    define _POSIX_C_SOURCE 200809L
+#   endif
+#   if !defined(_DEFAULT_SOURCE)
+#    define _DEFAULT_SOURCE
+#   endif
+#   if !defined(_XOPEN_SOURCE)
+#    define _XOPEN_SOURCE 700
+#   endif
 #  endif
 
 # define __STDC_WANT_LIB_EXT1__ 1
-
-#  if defined(__linux__)
-#   include <sys/syscall.h>
-#  elif defined(__sun)
-#   include <sys/filio.h>
-#   include <stropts.h>
-#  endif
 
 #  if defined(__linux__)
 #   include <sys/syscall.h>

--- a/include/bal/platform.h
+++ b/include/bal/platform.h
@@ -35,6 +35,7 @@
 #  elif defined(__linux__)
 #   undef _GNU_SOURCE
 #   define _GNU_SOURCE
+#   define __HAVE_POLLRDHUP__
 #  elif defined(__OpenBSD__)
 #   define __BSD__
 #   define __FreeBSD_PTHREAD_NP_11_3__
@@ -49,6 +50,9 @@
 #   define _BSD_SOURCE
 #   if !defined(_DEFAULT_SOURCE)
 #    define _DEFAULT_SOURCE
+#   endif
+#   if !defined(__DragonFly__)
+#    define __HAVE_POLLRDHUP__
 #   endif
 #   include <sys/param.h>
 #   if __FreeBSD_version >= 1202500

--- a/include/bal/platform.h
+++ b/include/bal/platform.h
@@ -31,13 +31,16 @@
 #   define __MACOS__
 #   undef _DARWIN_C_SOURCE
 #   define _DARWIN_C_SOURCE
+#   define __HAVE_LIBC_STRLCPY__
 #  elif defined(__linux__)
 #   undef _GNU_SOURCE
 #   define _GNU_SOURCE
-#  elif defined (__FreeBSD__)
+#  elif defined (__FreeBSD__) || defined (__OpenBSD__) || defined (__NetBSD__) ||
+        defined (__DragonFly__)
 #   define __BSD__
 #   undef _BSD_SOURCE
 #   define _BSD_SOURCE
+#   define __HAVE_LIBC_STRLCPY__
 #  endif
 #  if !defined(_POSIX_C_SOURCE)
 #   define _POSIX_C_SOURCE 200809L
@@ -48,6 +51,8 @@
 #  if !defined(_XOPEN_SOURCE)
 #   define _XOPEN_SOURCE 700
 #  endif
+
+# define __STDC_WANT_LIB_EXT1__ 1
 
 #  if defined(__linux__)
 #   include <sys/syscall.h>
@@ -136,6 +141,7 @@ typedef void* bal_threadret;
 
 #  define __WIN__
 #  define _CRT_SECURE_NO_WARNINGS
+#  define __WANT_STDC_SECURE_LIB__ 1
 #  include <winsock2.h>
 #  include <ws2tcpip.h>
 #  include <shlwapi.h>
@@ -234,9 +240,9 @@ typedef unsigned bal_threadret;
 # define BAL_EVT_ALL      0x000007ffU /**< Includes all available event types. */
 # define BAL_EVT_NORMAL   0x00000bbdU /**< Excludes write, oob-write, priority. */
 
-# define BAL_S_CONNECT 0x00000001U
-# define BAL_S_LISTEN  0x00000002U
-# define BAL_S_CLOSE   0x00000004U
+# define BAL_S_CONNECT    0x00000001U
+# define BAL_S_LISTEN     0x00000002U
+# define BAL_S_CLOSE      0x00000004U
 
 # if defined(__MACOS__)
 #  undef __HAVE_SO_ACCEPTCONN__

--- a/include/bal/platform.h
+++ b/include/bal/platform.h
@@ -83,6 +83,12 @@
 #   include <stropts.h>
 #  endif
 
+#  if defined(__BSD__)
+#   if !defined(__NetBSD__)
+#    include <pthread_np.h>
+#   endif
+#  endif
+
 #  include <sys/types.h>
 #  include <sys/socket.h>
 #  include <sys/select.h>

--- a/include/bal/platform.h
+++ b/include/bal/platform.h
@@ -35,7 +35,7 @@
 #  elif defined(__linux__)
 #   undef _GNU_SOURCE
 #   define _GNU_SOURCE
-#  elif defined (__FreeBSD__) || defined (__OpenBSD__) || defined (__NetBSD__) ||
+#  elif defined (__FreeBSD__) || defined (__OpenBSD__) || defined (__NetBSD__) || \
         defined (__DragonFly__)
 #   define __BSD__
 #   undef _BSD_SOURCE

--- a/sample/balclient.cc
+++ b/sample/balclient.cc
@@ -93,7 +93,7 @@ void balclient::async_events_cb(bal_socket* s, uint32_t events)
 
     if (bal_isbitset(events, BAL_EVT_READ)) {
         constexpr const size_t buf_size = 2048;
-        std::array<char, buf_size> buf;
+        std::array<char, buf_size> buf {};
         int read = bal_recv(s, buf.data(), buf.size() - 1, 0);
         if (read > 0) {
             printf("[" BAL_SOCKET_SPEC "] read %d bytes: '%s'\n", s->sd, read,

--- a/sample/balclient.cc
+++ b/sample/balclient.cc
@@ -46,10 +46,15 @@ int main(int argc, char** argv)
     int ret = bal_sock_create(&s, AF_INET, SOCK_STREAM, IPPROTO_TCP);
     EXIT_IF_FAILED(ret, "bal_sock_create");
 
+    string remote_host = balcommon::get_input_line("Enter server hostname",
+        balcommon::localaddr);
+
     ret = bal_asyncpoll(s, &balclient::async_events_cb, BAL_EVT_NORMAL);
     EXIT_IF_FAILED(ret, "bal_asyncpoll");
 
-    ret = bal_connect(s, balcommon::localaddr, balcommon::portnum);
+    printf("connecting to %s:%s...\n", remote_host.c_str(), balcommon::portnum);
+
+    ret = bal_connect(s, remote_host.c_str(), balcommon::portnum);
     EXIT_IF_FAILED(ret, "bal_connect");
 
     printf("running; ctrl+c to exit...\n");

--- a/sample/balcommon.cc
+++ b/sample/balcommon.cc
@@ -81,7 +81,7 @@ void balcommon::ctrl_c_handler_impl()
     quit();
 }
 
-void balcommon::print_last_lib_error(const std::string& func /* = std::string() */)
+void balcommon::print_last_lib_error(const string& func /* = std::string() */)
 {
     bal_error err {};
     bal_getlasterror(NULL, &err);
@@ -90,9 +90,23 @@ void balcommon::print_last_lib_error(const std::string& func /* = std::string() 
          << " (" << err.desc << ")" << endl;
 }
 
-void balcommon::print_startup_banner(const std::string& name)
+void balcommon::print_startup_banner(const string& name)
 {
     cout << name << " (libbal " << bal_get_versionstring() << ")" << endl;
+}
+
+string balcommon::get_input_line(const string& prompt,
+    const string& def)
+{
+    string input;
+
+    cout << prompt << " [" << def << "]: ";
+    getline(cin, input);
+
+    if (input.empty())
+        input = def;
+
+    return input;
 }
 
 #if defined(__WIN__)

--- a/sample/balcommon.hh
+++ b/sample/balcommon.hh
@@ -47,6 +47,8 @@ namespace balcommon
     void ctrl_c_handler_impl();
     void print_last_lib_error(const std::string& func = std::string());
     void print_startup_banner(const std::string& name);
+    std::string get_input_line(const std::string& prompt,
+        const std::string& def);
 
 # define EXIT_IF_FAILED(retval, func) \
     if (BAL_TRUE != retval) { \

--- a/src/bal.c
+++ b/src/bal.c
@@ -803,7 +803,7 @@ int bal_getaddrstrings(const bal_sockaddr* in, bool dns, bal_addrstrings* out)
             if (dns) {
                 get = _bal_getnameinfo(_BAL_NI_DNS, in, out->host, out->port);
                 if (BAL_FALSE == get)
-                    (void)strncpy(out->host, BAL_UNKNOWN, NI_MAXHOST);
+                    _bal_strcpy(out->host, NI_MAXHOST, BAL_UNKNOWN, sizeof(BAL_UNKNOWN));
             }
             if (PF_INET == ((struct sockaddr*)in)->sa_family)
                 out->type = BAL_AS_IPV4;

--- a/src/bal.c
+++ b/src/bal.c
@@ -123,7 +123,8 @@ int bal_close(bal_socket** s, bool destroy)
         }
 #endif
         else {
-            _bal_dbglog("closed socket "BAL_SOCKET_SPEC" (%p)", (*s)->sd, *s);
+            _bal_dbglog("closed socket "BAL_SOCKET_SPEC" (%p, mask = %08"PRIx32")",
+                (*s)->sd, *s, (*s)->state.mask);
             bal_setbitshigh(&(*s)->state.bits, BAL_S_CLOSE);
             bal_setbitslow(&(*s)->state.bits, BAL_S_CONNECT | BAL_S_LISTEN);
             closed = BAL_TRUE;

--- a/src/bal.c
+++ b/src/bal.c
@@ -160,18 +160,18 @@ int bal_shutdown(bal_socket* s, int how)
     return r;
 }
 
-int bal_connect(const bal_socket* s, const char* host, const char* port)
+int bal_connect(bal_socket* s, const char* host, const char* port)
 {
     int r = BAL_FALSE;
 
-    if (s && _bal_validstr(host) && _bal_validstr(port)) {
+    if (_bal_validsock(s) && _bal_validstr(host) && _bal_validstr(port)) {
         struct addrinfo* ai = NULL;
 
         if (BAL_TRUE == _bal_getaddrinfo(0, s->addr_fam, s->type, host, port, &ai)) {
             bal_addrlist al = {NULL, NULL};
 
             if (BAL_TRUE == _bal_aitoal(ai, &al)) {
-                r = bal_connectaddrlist((bal_socket*)s, &al);
+                r = bal_connectaddrlist(s, &al);
                 bal_freeaddrlist(&al);
             }
 

--- a/src/balerrors.c
+++ b/src/balerrors.c
@@ -90,7 +90,7 @@ void _bal_formaterrormsg(int err, char buf[BAL_MAXERROR], bool gai)
 #else
     if (gai) {
         const char* tmp = gai_strerror(err);
-        (void)strncpy(buf, tmp, strnlen(tmp, BAL_MAXERROR));
+        _bal_strcpy(buf, BAL_MAXERROR, tmp, strnlen(tmp, BAL_MAXERROR));
     } else {
      int finderr = -1;
 #if defined(__HAVE_XSI_STRERROR_R__)
@@ -102,12 +102,12 @@ void _bal_formaterrormsg(int err, char buf[BAL_MAXERROR], bool gai)
 #elif defined(__HAVE_GNU_STRERROR_R__)
         char* tmp = strerror_r(err, buf, BAL_MAXERROR);
         if (tmp != buf)
-            (void)strncpy(buf, tmp, strnlen(tmp, BAL_MAXERROR));
+            _bal_strcpy(buf, BAL_MAXERROR, tmp, strnlen(tmp, BAL_MAXERROR));
 #elif defined(__HAVE_STRERROR_S__)
         finderr = (int)strerror_s(buf, BAL_MAXERROR, err);
 #else
         char* tmp = strerror(err);
-        (void)strncpy(buf, tmp, strnlen(tmp, BAL_MAXERROR));
+        _bal_strcpy(buf, BAL_MAXERROR, tmp, strnlen(tmp, BAL_MAXERROR));
 #endif
 #if defined(__HAVE_XSI_STRERROR_R__) || defined(__HAVE_STRERROR_S__)
         assert(0 == finderr);

--- a/src/balinternal.c
+++ b/src/balinternal.c
@@ -1025,6 +1025,11 @@ pid_t _bal_gettid(void)
     if (0 != gettid)
         (void)_bal_handleerr(gettid);
     tid = (pid_t)tid64;
+# elif (defined(__BSD__) && !defined(__NetBSD__) && !defined(__OpenBSD__)) || \
+        defined(__DragonFly_getthreadid__)
+    tid = (pid_t)pthread_getthreadid_np();
+# elif defined(__OpenBSD__)
+    tid = (pid_t)getthrid();
 # elif defined(__linux__)
 #  if (defined(__GLIBC__) && (__GLIBC__ >= 2 && __GLIBC_MINOR__ >= 30))
     tid = gettid();

--- a/src/balinternal.c
+++ b/src/balinternal.c
@@ -163,7 +163,7 @@ int _bal_asyncpoll(bal_socket* s, bal_async_cb proc, uint32_t mask)
                 }
                 if (success) {
                     _bal_dbglog("added socket "BAL_SOCKET_SPEC" to list (%p"
-                                ", mask = %08x)", s->sd, s, s->state.mask);
+                                ", mask = %08"PRIx32")", s->sd, s, s->state.mask);
                 } else {
                     _bal_dbglog("error: failed to add socket "BAL_SOCKET_SPEC
                                 " to list!", s->sd);

--- a/src/balinternal.c
+++ b/src/balinternal.c
@@ -936,9 +936,9 @@ void _bal_socket_print(const bal_socket* s)
 {
     if (_bal_validptr(s)) {
         printf("%p:\n{\n  sd = "BAL_SOCKET_SPEC"\n  addr_fam = %d\n  type = %d\n"
-               "  proto = %d\nstate =\n  {\n  mask = %"PRIx32"\n  proc = %p\n  }"
-               "\n}\n", (void*)s, s->sd, s->addr_fam, s->type, s->proto,
-               s->state.mask, (void*)s->state.proc);
+               "  proto = %d\nstate =\n  {\n  mask = %"PRIx32"\n  proc = %"
+               PRIxPTR"\n  }\n}\n", (void*)s, s->sd, s->addr_fam, s->type, s->proto,
+               s->state.mask, (uintptr_t)s->state.proc);
     } else {
         printf("<null>\n");
     }

--- a/src/balinternal.c
+++ b/src/balinternal.c
@@ -356,7 +356,7 @@ int _bal_getnameinfo(int f, const bal_sockaddr* in, char* host, char* port)
     return r;
 }
 
-bool _bal_ispendingconn(bal_socket* s)
+bool _bal_ispendingconn(const bal_socket* s)
 {
     return _bal_validsock(s) && bal_isbitset(s->state.bits, BAL_S_CONNECT);
 }
@@ -544,8 +544,6 @@ void _bal_dispatchevents(bal_descriptor sd, bal_socket* s, uint32_t events)
     if (bal_isbitset(events, BAL_EVT_READ) && bal_bitsinmask(s, BAL_EVT_READ)) {
         if (bal_islistening(s)) {
             bal_setbitshigh(&_events, BAL_EVT_ACCEPT);
-        } else if (_bal_isclosedconn(s)) {
-            bal_setsbitshigh(&_events, BAL_EVT_CLOSE);
         } else {
             bal_setbitshigh(&_events, BAL_EVT_READ);
         }

--- a/src/balinternal.c
+++ b/src/balinternal.c
@@ -536,12 +536,16 @@ void _bal_dispatchevents(bal_descriptor sd, bal_socket* s, uint32_t events)
     if (bal_isbitset(events, BAL_EVT_ERROR) && bal_bitsinmask(s, BAL_EVT_ERROR))
         bal_setbitshigh(&_events, BAL_EVT_ERROR);
 
+    if (bal_isbitset(events, BAL_EVT_INVALID) && bal_bitsinmask(s, BAL_EVT_INVALID))
+        bal_setbitshigh(&_events, BAL_EVT_INVALID);
+
     bool close = bal_isbitset(events, BAL_EVT_CLOSE);
+    bool invalid = bal_isbitset(events, BAL_EVT_INVALID);
 
     if (0U != _events && _bal_validptr(s->state.proc))
         s->state.proc(s, _events);
 
-    if (close) {
+    if (close || invalid) {
         /* if the callback did the right thing, it has called bal_close and
          * possibly bal_sock_destroy. if it didn't call the latter, the socket
          * still resides in the list. presume that the callback is behaving
@@ -551,10 +555,10 @@ void _bal_dispatchevents(bal_descriptor sd, bal_socket* s, uint32_t events)
 
         if (removed) {
             _bal_dbglog("removed socket "BAL_SOCKET_SPEC" (%p) from list"
-                        " (close event)", sd, s);
+                        " (closed/invalid)", sd, s);
         } else {
             _bal_dbglog("socket "BAL_SOCKET_SPEC" destroyed by event"
-                        " handler (close event)", sd);
+                        " handler (closed/invalid)", sd);
         }
     }
 }

--- a/src/balinternal.c
+++ b/src/balinternal.c
@@ -447,10 +447,10 @@ short _bal_mask_topollflags(uint32_t mask)
 
     if (bal_isbitset(mask, BAL_EVT_PRIORITY))
         bal_setbitshigh(&retval, POLLPRI);
-
-#elif defined(__linux__)
+# if defined(__linux__)
     if (bal_isbitset(mask, BAL_EVT_CLOSE))
         bal_setbitshigh(&retval, POLLRDHUP);
+# endif
 #endif
 
     return retval;

--- a/src/balinternal.c
+++ b/src/balinternal.c
@@ -418,6 +418,9 @@ short _bal_mask_topollflags(uint32_t mask)
 
     if (bal_isbitset(mask, BAL_EVT_PRIORITY))
         bal_setbitshigh(&retval, POLLPRI);
+#elif defined(__linux__)
+    if (bal_isbitset(mask, BAL_EVT_CLOSE))
+        bal_setbitshigh(&retval, POLLRDHUP);
 #endif
 
     return retval;

--- a/src/balinternal.c
+++ b/src/balinternal.c
@@ -368,8 +368,7 @@ bool _bal_is_closed_conn(const bal_socket* s)
      * platform. If the socket were not asynchronous, this could cause an
      * indefinite hang. */
     return false;
-#endif
-
+#else
     if (!_bal_validsock(s))
         return true;
 
@@ -388,6 +387,7 @@ bool _bal_is_closed_conn(const bal_socket* s)
     }
 
     return false;
+#endif
 }
 
 uint32_t _bal_pollflags_to_events(short flags)

--- a/src/balinternal.c
+++ b/src/balinternal.c
@@ -361,7 +361,7 @@ bool _bal_ispendingconn(bal_socket* s)
     return _bal_validsock(s) && bal_isbitset(s->state.bits, BAL_S_CONNECT);
 }
 
-bool _bal_isclosedcircuit(const bal_socket* s)
+bool _bal_isclosedconn(const bal_socket* s)
 {
 #if defined(__WIN__)
     /* Windows doesn't have MSG_DONTWAIT, so this method is unacceptable for that
@@ -447,6 +447,7 @@ short _bal_mask_topollflags(uint32_t mask)
 
     if (bal_isbitset(mask, BAL_EVT_PRIORITY))
         bal_setbitshigh(&retval, POLLPRI);
+
 #elif defined(__linux__)
     if (bal_isbitset(mask, BAL_EVT_CLOSE))
         bal_setbitshigh(&retval, POLLRDHUP);

--- a/src/balinternal.c
+++ b/src/balinternal.c
@@ -1002,8 +1002,8 @@ void _bal_strcpy(char* dest, size_t destsz, const char* src, size_t srcsz)
         const char* src_cursor = src;
         char* dest_cursor = dest;
 
-        while (*src_cursor != '\0' && (src_cursor - src) < destsz - 1 &&
-               (src_cursor - src) < srcsz)
+        while (*src_cursor != '\0' && (uintptr_t)(src_cursor - src) < destsz - 1 &&
+               (uintptr_t)(src_cursor - src) < srcsz)
             *(dest_cursor++) = *(src_cursor++);
         *dest_cursor = '\0';
 #endif


### PR DESCRIPTION
- Use `POLLRDHUP` on Linux and FreeBSD to avoid spamming of read events after peer shuts down connection on stream socket.
- Utilize `WSAPoll` on Windows–works great!
- Improve support for older CMake versions (down to 3.13)
- Resolve warnings and errors on various configurations (GCC/Linux, MSVC/Windows, Clang/FreeBSD)
- Got rid of `strncpy` to avoid static analyzer warnings